### PR TITLE
Fix typo in init.lua preventing the usage of ScreenGuis

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -1164,7 +1164,7 @@ function Icon:_setToggleItemsVisible(bool, byIcon)
 		if not byIcon or byIcon.toggleItems[toggleItem] == nil then
 			local property = "Visible"
 			if toggleItem:IsA("LayerCollector") then
-				property = "Enbaled"
+				property = "Enabled"
 			end
 			toggleItem[property] = bool
 		end


### PR DESCRIPTION
There is a typo on line 1167 of init.lua which prevents changing the property "Enabled" for screenguis/LayerCollectors.